### PR TITLE
resume server support and team confirmation

### DIFF
--- a/app.py
+++ b/app.py
@@ -200,6 +200,22 @@ def dashboard():
 
         return redirect(url_for('dashboard'))
 
+@app.route('/teamconfirm/', methods=["POST"])
+def teamconfirm():
+    if request.remote_addr in config.confirm_ip:
+        team_name = request.form["team_name"].strip()
+        team_key = request.form["team_key"].strip()
+        try:
+            team = Team.get(Team.name == team_name)
+        except Team.DoesNotExist:
+            return "invalid", 403
+        if team.key == team_key:
+            return "ok", 200
+        else:
+            return "invalid", 403
+    else:
+        return "unauthorized", 401
+
 @app.route('/challenges/')
 @decorators.must_be_allowed_to("view challenges")
 @decorators.competition_running_required

--- a/config.py
+++ b/config.py
@@ -17,12 +17,22 @@ teams_on_graph = 10
 
 mail_from = "tjctf@sandbox1431.mailgun.org"
 
+# IPs that are allowed to confirm teams by posting to /teamconfirm/
+# Useful for verifying resumes and use with resume server.
+confirm_ip = []
+
 static_prefix = "http://127.0.0.1/tjctf-static/"
 static_dir = "{}/static/".format(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 custom_stylesheet = "tjctf.css"
 
 competition_begin = datetime(1970, 1, 1, 0, 0)
 competition_end = datetime(2018, 1, 1, 0, 0)
+
+# Are you using a resume server?
+resumes = True
+# If yes, where's it hosted? Otherwise, just put None.
+resume_server = "https://resumes.tjctf.org"
+
 
 def competition_is_running():
     return competition_begin < datetime.now() < competition_end

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -157,7 +157,7 @@
 
 <p>Feel free to submit up to 5 resume PDFs per team. These will be associated with your team by your team name and a representation of your team key, so keep it professional.</p>
 
-<form method="POST">
+<form method="POST" action="{{ config.resume_server }}">
     <input name="team_name" type="hidden" value="{{ team.name }}"/>
     <input name="team_key" type="hidden" value="{{ team.key.split("_")[1][:12] }}"/>
     <button class="btn waves-effect waves-light" type="submit">Add Resume</button>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -149,6 +149,25 @@
 <p>No score adjustments have been made.</p>
 {% endif %}
 </section>
+
+{% if config.resumes and team.eligible %}
+<section>
+<h4>Resume Submissions</h4>
+<p>Sponsors will have access to resumes submitted to our database. They may contact competitors about internship opportunities.</p>
+
+<p>Feel free to submit up to 5 resume PDFs per team. These will be associated with your team by your team name and a representation of your team key, so keep it professional.</p>
+
+<form method="POST">
+    <input name="team_name" type="hidden" value="{{ team.name }}"/>
+    <input name="team_key" type="hidden" value="{{ team.key.split("_")[1][:12] }}"/>
+    <button class="btn waves-effect waves-light" type="submit">Add Resume</button>
+</form>
+
+</section>
+{% endif %}
+
+
+<br><br>
 <div id="firstlogin" class="modal">
     <div class="modal-content">
         <h4>Welcome to {{ config.ctf_name }}!</h4>
@@ -158,7 +177,7 @@
          
         <p>Your Team Key will be under Login Information. It was also sent to your team email. This is the only way to log in, so distribute it to your team members.</p>
          
-        <p>Once that's done, we recommend you read the Rules and FAQ. Then, do some Practice to warm up for the competition, or join the Chat to meet your fellow competitors and ask questions. The competition will begin soon enough, but in the meanwhile, explore the site!</p>
+        <p>Once that's done, we recommend you read the Rules and FAQ. Then, do some Practice to warm up for the competition, submit team members' resumes to the Resume Database for sponsors to contact about resume opportunities, or join the Chat to meet your fellow competitors and ask questions. The competition will begin soon enough, but in the meanwhile, explore the site!</p>
     </div>
     <div class="modal-footer">
         <a href="#!" class="modal-action modal-close waves-effect waves-green btn-flat">Dismiss</a>


### PR DESCRIPTION
adds a boolean in config and a field to put in an address for an optional resume server
if resume server is on, then the dashboard will have a section with a button to post the team name and first 12 of the key to the resume server, and redirect to the resume server page for resume uploads.
Also adds a function to confirm whether a team, with a certain first 12 of the key, is a competing team, by posting to teamconfirm. config.py now has a new option: a list of public URLs that can request team confirmation.
